### PR TITLE
Bundle hashsum fix

### DIFF
--- a/src/__tests__/helpers.spec.ts
+++ b/src/__tests__/helpers.spec.ts
@@ -57,8 +57,8 @@ test('cache key should match', () => {
   expect([cacheKey, classicAcsCacheKey, modernAcsCacheKey, checksum]).toMatchSnapshot()
 })
 
-test('invalid cache key should throw', () => {
-  expect(() => getCacheKey('test', undefined)).toThrowError('Invalid key format provided: undefined')
+test("invalid cache key should default to 'cloud'", () => {
+  expect(getCacheKey('test', undefined)).toStrictEqual('lc-098f6bcd4621d373cade4e832627b4f6-lc.%m')
 })
 
 test('clientlib path is correct', () => {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -52,20 +52,18 @@ export function getCacheKey(entryPath: string, keyFormat: AEMLongCacheConfigurat
   let keyFormatString = ''
 
   switch (keyFormat) {
-    case 'cloud':
-      keyFormatString = 'lc-%s-lc.%m'
-      break
     case 'acs-classic':
       keyFormatString = '%s.%m'
       break
     case 'acs-modern':
       keyFormatString = '%m.ACSHASH%s'
       break
+    case 'cloud':
     default:
       if (typeof keyFormat === 'object' && keyFormat.type === 'custom' && keyFormat.format) {
         keyFormatString = keyFormat.format
       } else {
-        throw new Error(`Invalid key format provided: ${keyFormat}`)
+        keyFormatString = 'lc-%s-lc.%m'
       }
   }
 


### PR DESCRIPTION
Resolves an inconsistent bundle hashsum, along with ensuring `cloud` is used as the default cache key when none is defined.

References:
- https://github.com/aem-vite/import-rewriter/issues/6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Cache key generation now defaults to a cloud-style key when no format is provided, avoiding errors.
- Chores
  - Build process now writes non-entry chunks to disk, ensuring complete output artifacts.
- Tests
  - Updated tests to reflect the new default cache key behavior and maintain coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->